### PR TITLE
Fixes for Circle CI 2.0

### DIFF
--- a/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
+++ b/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
@@ -49,7 +49,6 @@ module Fastlane
       end
 
       def self.retrieve_uuid(provisioning_profile)
-        UI.message("About to execute PLISTBuddy command")
         `/usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin <<< $(security cms -D -i #{provisioning_profile.shellescape} 2> /dev/null)`.gsub("\n", "")
       end
 

--- a/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
+++ b/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
@@ -15,7 +15,7 @@ module Fastlane
           return
         end
 
-        path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+        path = target_directory
         # If the directory doesn't exist, create it first
         unless File.directory?(path)
           FileUtils.mkdir_p(path)

--- a/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
+++ b/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
@@ -15,6 +15,12 @@ module Fastlane
           return
         end
 
+        path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+        # If the directory doesn't exist, create it first
+        unless File.directory?(path)
+          FileUtils.mkdir_p(path)
+        end
+
         provisioning_profiles.each do |provisioning_profile|
           # Show the provisioning profile basename
           UI.message("Provisioning Profile: #{File.basename provisioning_profile}")
@@ -43,6 +49,7 @@ module Fastlane
       end
 
       def self.retrieve_uuid(provisioning_profile)
+        UI.message("About to execute PLISTBuddy command")
         `/usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin <<< $(security cms -D -i #{provisioning_profile.shellescape} 2> /dev/null)`.gsub("\n", "")
       end
 

--- a/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
+++ b/lib/fastlane/plugin/install_provisioning_profiles/actions/install_provisioning_profiles_action.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.retrieve_uuid(provisioning_profile)
-        `/usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin <<< $(security cms -D -i #{provisioning_profile.shellescape})`.gsub("\n", "")
+        `/usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin <<< $(security cms -D -i #{provisioning_profile.shellescape} 2> /dev/null)`.gsub("\n", "")
       end
 
       def self.uuid_exist(uuid)


### PR DESCRIPTION
This fixes an issue with OSX logging about a security issue when accessing the provisioning profile.

It also makes sure that the provisioning profile directory exists before we try and copy into it.  This is helpful if you are using this on CI where it boots up a VM and doesn't have everything set up for you.